### PR TITLE
Initialize project structure with stubs

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,24 @@
+"""User authentication helpers using Supabase."""
+
+from typing import Any, Dict
+
+# Placeholder for a Supabase client
+_supabase_client = None
+
+
+def login_user() -> Dict[str, Any]:
+    """Authenticate a user via Supabase.
+
+    Returns a dictionary with user information on success.
+    """
+    raise NotImplementedError("login_user needs Supabase integration")
+
+
+def fetch_user_data() -> Dict[str, Any]:
+    """Return the authenticated user's data."""
+    raise NotImplementedError("fetch_user_data needs Supabase integration")
+
+
+def logout_user() -> None:
+    """Log out the current user."""
+    raise NotImplementedError("logout_user needs Supabase integration")

--- a/calendar_view.py
+++ b/calendar_view.py
@@ -1,0 +1,18 @@
+"""View for displaying user shifts and marketplace shifts."""
+
+from typing import List, Dict
+
+
+def get_user_shifts(user_id: str) -> List[Dict]:
+    """Fetch shifts assigned to a user."""
+    raise NotImplementedError("Supabase query not implemented")
+
+
+def get_market_shifts() -> List[Dict]:
+    """Fetch shifts available on the market."""
+    raise NotImplementedError("Supabase query not implemented")
+
+
+def display_calendar(user_id: str) -> None:
+    """Render the calendar UI in Streamlit."""
+    raise NotImplementedError("Streamlit calendar display not implemented")

--- a/db.py
+++ b/db.py
@@ -1,0 +1,26 @@
+"""Database interaction layer using Supabase."""
+
+from typing import Dict, Any
+
+# Placeholder for a Supabase client
+_supabase_client = None
+
+
+def insert_shift(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Insert a new shift record into the database."""
+    raise NotImplementedError("DB insert not implemented")
+
+
+def update_shift(shift_id: str, data: Dict[str, Any]) -> Dict[str, Any]:
+    """Update an existing shift record."""
+    raise NotImplementedError("DB update not implemented")
+
+
+def delete_shift(shift_id: str) -> None:
+    """Delete a shift from the database."""
+    raise NotImplementedError("DB delete not implemented")
+
+
+def log_shift_change(action: str, data: Dict[str, Any]) -> None:
+    """Record a change to a shift in the history table."""
+    raise NotImplementedError("DB logging not implemented")

--- a/main.py
+++ b/main.py
@@ -1,0 +1,19 @@
+"""Main entry point for the Streamlit application."""
+
+import streamlit as st
+
+
+def set_page_config():
+    """Configure Streamlit page settings."""
+    st.set_page_config(page_title="Calendario", page_icon="📅", layout="wide")
+
+
+def main():
+    """Launch the Streamlit app."""
+    set_page_config()
+    st.write("# Calendario de Turnos")
+    # Navigation between views would be implemented here
+
+
+if __name__ == "__main__":
+    main()

--- a/shift_market.py
+++ b/shift_market.py
@@ -1,0 +1,18 @@
+"""Helpers for managing the shift marketplace."""
+
+from typing import Dict
+
+
+def offer_shift(user_id: str, shift_id: str) -> Dict:
+    """Mark a user's shift as available."""
+    raise NotImplementedError("Supabase update not implemented")
+
+
+def take_shift(user_id: str, shift_id: str) -> Dict:
+    """Request to take an offered shift."""
+    raise NotImplementedError("Supabase update not implemented")
+
+
+def confirm_shift_transfer(from_user_id: str, to_user_id: str, shift_id: str) -> Dict:
+    """Confirm a shift transfer between users."""
+    raise NotImplementedError("Supabase update not implemented")

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,25 @@
+"""Utility functions used across the project."""
+
+from datetime import datetime
+from typing import Dict
+
+
+def format_datetime(timestamp: float) -> str:
+    """Return a formatted date-time string."""
+    return datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def validate_shift_data(data: Dict) -> bool:
+    """Basic validation of shift dictionary structure."""
+    required_keys = {"id", "start", "end", "type"}
+    return required_keys.issubset(data.keys())
+
+
+def get_shift_color(shift_type: str) -> str:
+    """Return a color based on the shift type."""
+    mapping = {
+        "morning": "green",
+        "evening": "orange",
+        "night": "blue",
+    }
+    return mapping.get(shift_type, "gray")


### PR DESCRIPTION
## Summary
- add minimal project Python modules
- include stub implementations for authentication, database, calendar view, shift marketplace, and utility helpers
- configure Streamlit entrypoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f82450aa4832b8f0488332b1d4181