### PR TITLE
Implement basic Streamlit app

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -1,24 +1,22 @@
 """User authentication helpers using Supabase."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
-# Placeholder for a Supabase client
-_supabase_client = None
-
-
-def login_user() -> Dict[str, Any]:
-    """Authenticate a user via Supabase.
-
-    Returns a dictionary with user information on success.
-    """
-    raise NotImplementedError("login_user needs Supabase integration")
+import streamlit as st
 
 
-def fetch_user_data() -> Dict[str, Any]:
-    """Return the authenticated user's data."""
-    raise NotImplementedError("fetch_user_data needs Supabase integration")
+def login_user(username: str) -> Dict[str, Any]:
+    """Authenticate a user and store their info in session state."""
+    user_data = {"id": username, "username": username}
+    st.session_state["user"] = user_data
+    return user_data
+
+
+def fetch_user_data() -> Optional[Dict[str, Any]]:
+    """Return the authenticated user's data if available."""
+    return st.session_state.get("user")
 
 
 def logout_user() -> None:
-    """Log out the current user."""
-    raise NotImplementedError("logout_user needs Supabase integration")
+    """Log out the current user and clear session data."""
+    st.session_state.pop("user", None)

--- a/calendar_view.py
+++ b/calendar_view.py
@@ -2,17 +2,26 @@
 
 from typing import List, Dict
 
+import streamlit as st
+from db import _get_shifts
+
 
 def get_user_shifts(user_id: str) -> List[Dict]:
-    """Fetch shifts assigned to a user."""
-    raise NotImplementedError("Supabase query not implemented")
+    """Fetch shifts assigned to a user from session state."""
+    return [s for s in _get_shifts() if s.get("user_id") == user_id]
 
 
 def get_market_shifts() -> List[Dict]:
     """Fetch shifts available on the market."""
-    raise NotImplementedError("Supabase query not implemented")
+    market = st.session_state.get("market", {})
+    return [{"shift_id": sid, "offered_by": uid} for sid, uid in market.items()]
 
 
 def display_calendar(user_id: str) -> None:
     """Render the calendar UI in Streamlit."""
-    raise NotImplementedError("Streamlit calendar display not implemented")
+    st.subheader("Mis turnos")
+    shifts = get_user_shifts(user_id)
+    if shifts:
+        st.table(shifts)
+    else:
+        st.write("No tienes turnos asignados.")

--- a/db.py
+++ b/db.py
@@ -1,26 +1,40 @@
 """Database interaction layer using Supabase."""
 
-from typing import Dict, Any
+from typing import Dict, Any, List
 
-# Placeholder for a Supabase client
-_supabase_client = None
+import streamlit as st
+
+
+def _get_shifts() -> List[Dict[str, Any]]:
+    """Return the list that stores shifts in session state."""
+    return st.session_state.setdefault("shifts", [])
 
 
 def insert_shift(data: Dict[str, Any]) -> Dict[str, Any]:
-    """Insert a new shift record into the database."""
-    raise NotImplementedError("DB insert not implemented")
+    """Insert a new shift record into the session state database."""
+    _get_shifts().append(data)
+    log_shift_change("insert", data)
+    return data
 
 
 def update_shift(shift_id: str, data: Dict[str, Any]) -> Dict[str, Any]:
     """Update an existing shift record."""
-    raise NotImplementedError("DB update not implemented")
+    for shift in _get_shifts():
+        if shift.get("id") == shift_id:
+            shift.update(data)
+            log_shift_change("update", {"id": shift_id, **data})
+            break
+    return data
 
 
 def delete_shift(shift_id: str) -> None:
-    """Delete a shift from the database."""
-    raise NotImplementedError("DB delete not implemented")
+    """Delete a shift from the session state database."""
+    shifts = _get_shifts()
+    st.session_state["shifts"] = [s for s in shifts if s.get("id") != shift_id]
+    log_shift_change("delete", {"id": shift_id})
 
 
 def log_shift_change(action: str, data: Dict[str, Any]) -> None:
-    """Record a change to a shift in the history table."""
-    raise NotImplementedError("DB logging not implemented")
+    """Record a change to a shift in the history list."""
+    history = st.session_state.setdefault("history", [])
+    history.append({"action": action, **data})

--- a/main.py
+++ b/main.py
@@ -2,17 +2,92 @@
 
 import streamlit as st
 
+from auth import login_user, fetch_user_data, logout_user
+from calendar_view import display_calendar
+from shift_market import offer_shift, take_shift, _get_market
 
-def set_page_config():
+
+def set_page_config() -> None:
     """Configure Streamlit page settings."""
     st.set_page_config(page_title="Calendario", page_icon="📅", layout="wide")
 
 
-def main():
+def show_login() -> None:
+    """Display a simple login form."""
+    st.write("# Iniciar sesión")
+    username = st.text_input("Usuario")
+    if st.button("Entrar") and username:
+        login_user(username)
+        st.experimental_rerun()
+
+
+def show_calendar(user: dict) -> None:
+    """Show the user's calendar."""
+    display_calendar(user["id"])
+
+
+def show_shift_market(user: dict) -> None:
+    """Interface to offer and take shifts."""
+    st.subheader("Mercado de turnos")
+
+    with st.form("offer_form"):
+        st.write("Ofrecer turno")
+        shift_id = st.text_input("ID del turno a ofrecer")
+        if st.form_submit_button("Ofrecer") and shift_id:
+            offer_shift(user["id"], shift_id)
+            st.experimental_rerun()
+
+    st.write("---")
+    st.write("Turnos disponibles")
+    market = _get_market()
+    if market:
+        st.table([
+            {"shift_id": sid, "ofrecido_por": uid} for sid, uid in market.items()
+        ])
+    else:
+        st.write("No hay turnos disponibles.")
+
+    with st.form("take_form"):
+        st.write("Tomar turno")
+        take_id = st.text_input("ID del turno a tomar")
+        if st.form_submit_button("Solicitar") and take_id:
+            take_shift(user["id"], take_id)
+            st.experimental_rerun()
+
+
+def show_subscription() -> None:
+    """Allow the user to store a subscription calendar link."""
+    st.subheader("Suscripción de calendario")
+    url = st.text_input(
+        "Enlace de suscripción", value=st.session_state.get("subscription_url", "")
+    )
+    st.session_state["subscription_url"] = url
+
+
+def main() -> None:
     """Launch the Streamlit app."""
     set_page_config()
-    st.write("# Calendario de Turnos")
-    # Navigation between views would be implemented here
+    user = fetch_user_data()
+
+    if not user:
+        show_login()
+        return
+
+    st.sidebar.write(f"Hola, {user['username']}")
+    if st.sidebar.button("Cerrar sesión"):
+        logout_user()
+        st.experimental_rerun()
+
+    page = st.sidebar.radio(
+        "Navegación", ["Calendario", "Mercado", "Suscripción"]
+    )
+
+    if page == "Calendario":
+        show_calendar(user)
+    elif page == "Mercado":
+        show_shift_market(user)
+    else:
+        show_subscription()
 
 
 if __name__ == "__main__":

--- a/shift_market.py
+++ b/shift_market.py
@@ -2,17 +2,44 @@
 
 from typing import Dict
 
+import streamlit as st
+from db import _get_shifts
+
+
+def _get_market() -> Dict[str, str]:
+    """Return the marketplace mapping from session state."""
+    return st.session_state.setdefault("market", {})
+
 
 def offer_shift(user_id: str, shift_id: str) -> Dict:
-    """Mark a user's shift as available."""
-    raise NotImplementedError("Supabase update not implemented")
+    """Mark a user's shift as available in the market."""
+    _get_market()[shift_id] = user_id
+    return {"shift_id": shift_id, "offered_by": user_id}
 
 
 def take_shift(user_id: str, shift_id: str) -> Dict:
     """Request to take an offered shift."""
-    raise NotImplementedError("Supabase update not implemented")
+    market = _get_market()
+    if shift_id not in market:
+        return {"error": "Shift not available"}
+    st.session_state.setdefault("requests", {})[shift_id] = user_id
+    return {"shift_id": shift_id, "requested_by": user_id}
 
 
 def confirm_shift_transfer(from_user_id: str, to_user_id: str, shift_id: str) -> Dict:
     """Confirm a shift transfer between users."""
-    raise NotImplementedError("Supabase update not implemented")
+    market = _get_market()
+    if market.get(shift_id) != from_user_id:
+        return {"error": "Transfer not valid"}
+
+    del market[shift_id]
+    requests = st.session_state.setdefault("requests", {})
+    requests.pop(shift_id, None)
+
+    # update shift owner
+    for shift in _get_shifts():
+        if shift.get("id") == shift_id:
+            shift["user_id"] = to_user_id
+            break
+
+    return {"shift_id": shift_id, "from": from_user_id, "to": to_user_id}


### PR DESCRIPTION
## Summary
- build simple authentication helper for Streamlit session
- create in-memory DB helper functions
- add calendar and marketplace views
- build Streamlit interface with navigation and subscription input

## Testing
- `python -m py_compile auth.py calendar_view.py db.py main.py shift_market.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_683f87324668832ba45bc3fb5e230939